### PR TITLE
fix weave information.

### DIFF
--- a/day-1/DescomplicandoKubernetes-Day1.md
+++ b/day-1/DescomplicandoKubernetes-Day1.md
@@ -80,7 +80,7 @@ Abaixo um diagrama que mostra a arquitetura do k8s:
 
 - NodePort Services: 30000-32767 TCP
 
-Você você opte pelo [Weave](https://weave.works) como *pod network*, devem ser liberadas também as portas 6783 e 6784 TCP.
+Se você optar pelo [Weave](https://weave.works) como *pod network*, devem ser liberadas também as portas 6783 e 6784 TCP.
 
 ## Tá, mas qual tipo de aplicação eu devo rodar sobre o k8s?
 


### PR DESCRIPTION
-- Você você opte pelo [Weave](https://weave.works) como *pod network*, devem ser liberadas também as portas 6783 e 6784 TCP.

++ Se você optar pelo [Weave](https://weave.works) como *pod network*, devem ser liberadas também as portas 6783 e 6784 TCP.