### PR TITLE
faltando o l no kubectl

### DIFF
--- a/day-1/DescomplicandoKubernetes-Day1.md
+++ b/day-1/DescomplicandoKubernetes-Day1.md
@@ -1064,7 +1064,7 @@ pod "nginx" deleted
 Vamos recriá-lo, agora a partir do nosso arquivo YAML:
 
 ```
-# kubect create -f meu-primeiro.yaml
+# kubectl create -f meu-primeiro.yaml
 pod/nginx created
 ```
 


### PR DESCRIPTION
Faltando a letra 'l' do comando 'kubectl'