### PR TITLE
Retirar o restante do comando kubeadm init...

### DIFF
--- a/day-1/DescomplicandoKubernetes-Day1.md
+++ b/day-1/DescomplicandoKubernetes-Day1.md
@@ -621,7 +621,7 @@ Antes de inicializarmos o *cluster*, vamos efetuar o *download* das imagens que 
 Execute o comando abaixo também apenas no nó *master* para a inicialização do cluster. Caso tudo esteja bem, será apresentada ao término de sua execução o comando que deve ser executado nos demais nós para ingressar no *cluster*.
 
 ```
-# kubeadm init --apiserver-advertise-address $(hostname -i)
+# kubeadm init
 ```
 
 A saída do comando será algo similar ao abaixo:


### PR DESCRIPTION
Para ajustar de acordo com o vídeo...
E o comando completo também apresentou erro em distribuições RedHat instalado na virtualbox.
Já o comando "kubeadm init", somente, executou sem problemas.