### PR TITLE
Alterado o caminho do arquivo para configuração do parâmetro cgroup-d…

### DIFF
--- a/day-1/DescomplicandoKubernetes-Day1.md
+++ b/day-1/DescomplicandoKubernetes-Day1.md
@@ -802,8 +802,9 @@ Para alterar o *driver* do cgroup em distibuições Debian e similares:
 Para alterar o *driver* do cgroup em distribuições RedHat e similares:
 
 ```
-# sed -i "s/cgroup-driver=systemd/cgroup-driver=cgroupfs/g" /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+# sed -i "s/cgroup-driver=systemd/cgroup-driver=cgroupfs/g" /var/lib/kubelet/kubeadm-flags.env
 ```
+> Obs.: O arquivo '/var/lib/kubelet/kubeadm-flags.env' só será criado após a execução do comando "kubeadm init" ou "kubeadm join", seja no master ou no worker, respectivamente. 
 
 É preciso reiniciar o daemon e restartar o kubelet:
 


### PR DESCRIPTION
**- O que foi modificado:** 
* O caminho do arquivo para modificação do parâmetro "--cgroup-driver" foi modificado para "/var/lib/kubelet/kubeadm-flags.env" para Red Hat.
* Adicionado observação que o arquivo "/var/lib/kubelet/kubeadm-flags.env" só é criado após a execução do comando "kubeadm init" ou "kubeadm join".

**- Por que foi modificado:**
* A variável KUBELET_KUBEADM_ARGS, por meio da qual é configurado o parâmetro "--cgroup-driver", está presente no arquivo "/var/lib/kubelet/kubeadm-flags.env" para ambiente Red Hat, e não diretamente no arquivo "/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf" como citado anteriormente.
