### PR TITLE
Add uma observacao citada pelo jeferson na live do dia2 sobre o kube-scheduller

### DIFF
--- a/day-2/DescomplicandoKubernetes-Day2.md
+++ b/day-2/DescomplicandoKubernetes-Day2.md
@@ -34,7 +34,7 @@
 
 **[kube-apiserver](https://kubernetes.io/docs/concepts/overview/components/#kube-apiserver)** é a central de operações do cluster k8s. Todas as chamadas, internas ou externas são tratadas por ele. Ele é o único que conecta no ETCD.
 
-**[kube-scheduller](https://kubernetes.io/docs/concepts/overview/components/#kube-apiserver)** usa um algoritmo para verificar em qual determinado pod deverá ser hospedado. Ele verifica os recursos disponíveis do node para verificar qual o melhor node para receber aquele pod.
+**[kube-scheduller](https://kubernetes.io/docs/concepts/overview/components/#kube-apiserver)** usa um algoritmo para verificar em qual node o pod deverá ser hospedado. Ele verifica os recursos disponíveis do node para verificar qual o melhor node para receber aquele pod.
 
 No **[ETCD](https://kubernetes.io/docs/concepts/overview/components/#etcd)** são armazenados o estado do cluster, rede e outras informações persistentes. 
 


### PR DESCRIPTION
Um informacao pequena porem que ajuda nos detalhes da documentacao.
A mudanca desse commit, adiciona a palavra 'node' como parte da descricao do kube-scheduller.
