### PR TITLE
Add info pacote cliente nfs para familia Redhat

### DIFF
--- a/day-4/DescomplicandoKubernetes-Day4.md
+++ b/day-4/DescomplicandoKubernetes-Day4.md
@@ -147,7 +147,7 @@ No Debian/Ubuntu:
 # apt-get install nfs-kernel-server -y
 ```
 
-No CentOS/RedHat:
+No CentOS/RedHat tanto no servidor quanto nos nodes o pacote será o mesmo:
 
 ```
 # sudo yum install nfs-utils -y


### PR DESCRIPTION
Para nodes da família RedHat/CentOS o pacote referente ao cliente NFS será o mesmo do servidor, portanto nfs-utils. 