### PR TITLE
Adicionando verbo create na cluster role

### DIFF
--- a/day-5/DescomplicandoKubernetes-Day5.md
+++ b/day-5/DescomplicandoKubernetes-Day5.md
@@ -466,6 +466,7 @@ rules:
   - configmaps
   verbs:
   - get
+  - create
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Fazendo o exercício e olhandos os logs percebi que o ingress precisa de permissão create além do get no configmaps.