### PR TITLE
Alterado o Day4 - initContainers

### DIFF
--- a/day-4/DescomplicandoKubernetes-Day4.md
+++ b/day-4/DescomplicandoKubernetes-Day4.md
@@ -1077,11 +1077,7 @@ spec:
   initContainers:
   - name: install
     image: busybox
-    command:
-    - wget
-    - "-O"
-    - "/work-dir/index.html"
-    - http://kubernetes.io
+    command: ['wget','-O','/work-dir/index.html','http://linuxtips.io']
     volumeMounts:
     - name: workdir
       mountPath: "/work-dir"

--- a/day-4/DescomplicandoKubernetes-Day4.md
+++ b/day-4/DescomplicandoKubernetes-Day4.md
@@ -1049,10 +1049,14 @@ kubectl create -f pod-configmap-file.yaml
 
 # InitContainers
 
-> **Seção em construção...**
-> **Falta definir o conceito de Init Containers...**
+O objeto do tipo **Init Containers** são um ou mais containers que são executados antes do container de um aplicativo em um Pod. Os containers de inicialização podem conter utilitários ou scripts de configuração não presentes em uma imagem de aplicativo.
 
-Crie o seguinte arquivo:
+- Os containers de inicialização sempre são executados até a conclusão.
+- Cada container init deve ser concluído com sucesso antes que o próximo comece.
+
+Se o container init de um pod falhar, o Kubernetes reiniciará repetidamente o pod até que o container init tenha êxito. No entanto, se o pod tiver o `restartPolicy` como `Never` o Kubernetes não reiniciará o pod, e o container principal não irá ser executado.
+
+Crie o pod a partir do manifesto:
 
 ```
 vim nginx-initcontainer.yaml
@@ -1186,7 +1190,19 @@ Events:
   Normal  Started    2m59s  kubelet, k8s3      Started container
 ```
 
-Vamos remover o pod a partir do manifesto:
+Coletando os logs do container init:
+
+```
+kubectl logs init-demo -c install 
+Connecting to linuxtips.io (23.236.62.147:80)
+Connecting to www.linuxtips.io (35.247.254.172:443)
+wget: note: TLS certificate validation not implemented
+saving to '/work-dir/index.html'
+index.html           100% |********************************|  765k  0:00:00 ETA
+'/work-dir/index.html' saved
+```
+
+E por último vamos remover o pod a partir do manifesto:
 
 ```
 kubectl delete -f nginx-initcontainer.yaml

--- a/day-4/DescomplicandoKubernetes-Day4.md
+++ b/day-4/DescomplicandoKubernetes-Day4.md
@@ -1054,7 +1054,7 @@ O objeto do tipo **Init Containers** são um ou mais containers que são executa
 - Os containers de inicialização sempre são executados até a conclusão.
 - Cada container init deve ser concluído com sucesso antes que o próximo comece.
 
-Se o container init de um pod falhar, o Kubernetes reiniciará repetidamente o pod até que o container init tenha êxito. No entanto, se o pod tiver o `restartPolicy` como `Never` o Kubernetes não reiniciará o pod, e o container principal não irá ser executado.
+Se o container init de um pod falhar, o Kubernetes reiniciará repetidamente o pod até que o container init tenha êxito. No entanto, se o pod tiver o ``restartPolicy`` como ``Never`` o Kubernetes não reiniciará o pod, e o container principal não irá ser executado.
 
 Crie o pod a partir do manifesto:
 


### PR DESCRIPTION
- Alterei o command para array, conforme a doc: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
- Alterei a URL http://kubernetes.io para http://linuxtips.io, porque com a URL do kubernetes está dando erro de TLS.
" Para suportar downloads criptografados de HTTP (HTTPS), o Wget deve ser compilado com uma biblioteca SSL externa, atualmente OpenSSL. Se o Wget for compilado sem suporte a SSL, nenhuma dessas opções estará disponível. " http://linux.die.net/man/1/wget
```
Connecting to kubernetes.io (147.75.40.148:80)
Connecting to kubernetes.io (147.75.40.148:443)
wget: note: TLS certificate validation not implemented
wget: TLS error from peer (alert code 80): 80
```
```
$ kubectl get pods
NAME        READY   STATUS       RESTARTS   AGE
init-demo   0/1     Init:Error   3          65s
```
Coletei o log da seguinte forma:
```
kubectl logs init-demo -c install
```
Após a alteração, funcionou de boas..

```
$ kubectl logs init-demo -c install 
Connecting to linuxtips.io (23.236.62.147:80)
Connecting to www.linuxtips.io (35.247.254.172:443)
wget: note: TLS certificate validation not implemented
saving to '/work-dir/index.html'
index.html           100% |********************************|  765k  0:00:00 ETA
'/work-dir/index.html' saved
```
```
$ kubectl get pods
NAME        READY   STATUS    RESTARTS   AGE
init-demo   1/1     Running   0          12s
```