### PR TITLE
Update DescomplicandoKubernetes-Day1.md

### DIFF
--- a/day-1/DescomplicandoKubernetes-Day1.md
+++ b/day-1/DescomplicandoKubernetes-Day1.md
@@ -1003,6 +1003,12 @@ A instalação do Docker pode ser realizada com apenas um comando, que deve ser 
 # curl -fsSL https://get.docker.com | bash
 ```
 
+Para travar a uma versão especifica do docker utilize o seguinte comando:
+
+```
+# export VERSION=<versão do docker> && curl -fsSL https://get.docker.com | bash
+```
+
 Embora a maneira anterior seja a mais fácil, não permite o controle de opções. Por esse motivo, a documentação do Kubernetes sugere uma instalação mais controlada seguindo os passos disponíveis em: https://kubernetes.io/docs/setup/production-environment/container-runtimes/
 
 **Caso escolha o método mais fácil**, os próximos comandos são muito importantes, pois garantem que o driver ``Cgroup`` do Docker será configurado para o ``systemd``, que é o gerenciador de serviços padrão utilizado pelo Kubernetes.

--- a/day-3/DescomplicandoKubernetes-Day3.md
+++ b/day-3/DescomplicandoKubernetes-Day3.md
@@ -950,6 +950,9 @@ spec:
       labels:
         system: Strigus
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - name: nginx
         image: nginx:1.7.9
@@ -957,7 +960,7 @@ spec:
         - containerPort: 80
 ```
 
-Mas antes vamos permitir que todos os nossos nodes executem pods:
+Caso não queria utilizar a diretiva 'tolerations', podemos também utilizar a remoção do taint nas masters como a seguir: 
 
 ```
 kubectl taint nodes --all node-role.kubernetes.io/master-


### PR DESCRIPTION
Opção para instalar versões específicas do Docker.
Kubernetes não dará mais suporte ao Docker como Container Runtime.