### PR TITLE
Correção de caminho /etc/exportfs

### DIFF
--- a/day-4/DescomplicandoKubernetes-Day4.md
+++ b/day-4/DescomplicandoKubernetes-Day4.md
@@ -1837,7 +1837,7 @@ sudo chmod -R 777 /opt/prometheus/
 Adicione as linhas para mapear os diretório para dentro do NFS:
 
 ```
-sudo vim /etc/exportfs
+sudo vim /etc/exports
 
     /opt/prometheus *(rw,sync,subtree_check,no_root_squash)
     /opt/alertmanager *(rw,sync,subtree_check,no_root_squash)


### PR DESCRIPTION
Ao tentar executar os passos estava com problemas, então pedi ajuda para @luizdores e foi identificado um erro de digitação no caminho ```sudo vim /etc/exportfs```. O caminho correto é ```sudo vim /etc/exports```