### PR TITLE
Correção keys-only listagem chaves pods namespace ```default```

### DIFF
--- a/day-6/DescomplicandoKubernetes-Day6.md
+++ b/day-6/DescomplicandoKubernetes-Day6.md
@@ -353,7 +353,7 @@ kubectl exec -it etcd-minikube -n kube-system \
 --cacert=/var/lib/minikube/certs/etcd/ca.crt \
 --key=/var/lib/minikube/certs/etcd/server.key \
 --cert=/var/lib/minikube/certs/etcd/server.crt get /registry/pods/default \
---prefix=true -keys-only
+--prefix=true --keys-only
 ```
 
 Output:


### PR DESCRIPTION
Estava --> ```-keys-only```, estou seguindo os passos e acabei encontrando esse erro,
o correto é ```--keys-only```, no copia e cola acabei não vendo.