### PR TITLE
Update DescomplicandoKubernetes-Day1.md

### DIFF
--- a/day-1/DescomplicandoKubernetes-Day1.md
+++ b/day-1/DescomplicandoKubernetes-Day1.md
@@ -1368,7 +1368,7 @@ kubectl completion bash > /etc/bash_completion.d/kubectl
 Efetue *logoff* e *login* para carregar o *autocomplete*. Caso não deseje, execute:
 
 ```
-source < (kubectl completion bash)
+source <(kubectl completion bash)
 ```
 
 ## Verificando os namespaces e pods


### PR DESCRIPTION
removendo o espaço no comando: source < (kubectl completion bash), para: source <(kubectl completion bash)