### PR TITLE
Update exame_tips.md

### DIFF
--- a/pt/extras/exame_tips.md
+++ b/pt/extras/exame_tips.md
@@ -4,8 +4,8 @@
 
  * Dominar o kubectl:
     * explain   - ex: ``kubecetl explain deployment --recursive``
-    * create    - ex: ``kubectl create nginx --image nginx -o yaml``
-    * dry-run   - ex: ``kubectl create nginx --image nginx -o yaml``
+    * create    - ex: ``kubectl create deployment nginx --image nginx -o yaml``
+    * dry-run   - ex: ``kubectl create deployment nginx --image nginx -o yaml --dry-run=client``
     * json-path - ex: ``kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="ExternalIP")].address}'``
 
  * Básico no VIM:


### PR DESCRIPTION
Pequena correção nas instruções `create` e `dry-run` do `kubectl`.
Estava faltando o tipo de objeto a ser criado e a flag de dry-run.