### PR TITLE
adicionado parametro storageClassName no dayfour

### DIFF
--- a/pt/day_four/descomplicando_kubernetes.md
+++ b/pt/day_four/descomplicando_kubernetes.md
@@ -250,6 +250,7 @@ spec:
   accessModes:
   - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
   nfs:
     path: /opt/dados
     server: 10.138.0.2
@@ -319,6 +320,7 @@ spec:
   resources:
     requests:
       storage: 800Mi
+  storageClassName: nfs
 ```
 
 Crie o ``PersitentVolumeClaim`` a partir do manifesto.


### PR DESCRIPTION
Não estava conseguindo criar o PV e PVC no kind. No meu caso, o PVC estava usando um storageClassName padrão e não conseguia encontrar o PV para fazer o bind. Acrescentei um parâmetro `storageClassName: nfs` tanto no PV quanto no PVC e deu certo.

