### PR TITLE
Update API version of CronJob to batch/v1

### DIFF
--- a/pt/day_four/descomplicando_kubernetes.md
+++ b/pt/day_four/descomplicando_kubernetes.md
@@ -573,7 +573,7 @@ vim primeiro-cron.yaml
 Informe o seguinte conteúdo.
 
 ```yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: giropops-cron


### PR DESCRIPTION
The batch/v1beta1 API version of CronJob will no longer be served in v1.25.
- Migrate manifests and API clients to use the batch/v1 API version, available since v1.21.