### PR TITLE
Atualiza comando para instalar kind no MacOS

### DIFF
--- a/pt/day_one/README.md
+++ b/pt/day_one/README.md
@@ -580,7 +580,10 @@ sudo brew install kind
 ou
 
 ```
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-darwin-amd64
+# For Intel Macs
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-darwin-amd64
+# For M1 / ARM Macs
+[ $(uname -m) = arm64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-darwin-arm64
 chmod +x ./kind
 mv ./kind /usr/bin/kind
 ```


### PR DESCRIPTION
Esse PR visa atualizar o comando que instala o `kind` no MacOS.

O comando atual foca a instalação apenas computadores Mac com processadores Intel.

Essa atualização, [baseada na documentação do próprio kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installing-from-release-binaries), garante que a versão mais adequada seja instalada, seja para computadores com processadores Intel ou Apple Silicon.