### PR TITLE
fix: Ajustando o parâmetro replicas para receber uma variável em vez de um valor fixo

### DIFF
--- a/pt/day-16/README.md
+++ b/pt/day-16/README.md
@@ -390,7 +390,7 @@ metadata:
     app: redis 
   name: redis-deployment
 spec:
-  replicas: 1
+  replicas: {{ .Values.redis.replicas }}
   selector:
     matchLabels:
       app: redis


### PR DESCRIPTION
O deployment do redis está com o valor fixo para a quantidade de réplicas:
```yaml
spec:
  replicas: {{ .Values.redis.replicas }}
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
    spec:
      containers:
      - image: {{ .Values.redis.image }}
        name: redis
```
A documentação faz menção a utilizar a variável {{ .Values.redis.replicas }} para este valor.  Desta forma a sugestão foi para alterar para:
```yaml
spec:
  replicas: {{ .Values.redis.replicas }}
  ....
  ```