### PR TITLE
fix: Ajustando o parâmetro NodePort após consolidar todos manifestos 

### DIFF
--- a/pt/day-16/README.md
+++ b/pt/day-16/README.md
@@ -1084,7 +1084,7 @@ spec:
     protocol: TCP
     name: {{ $port.name }}
     {{ if eq $port.serviceType "NodePort" }}
-    nodePort: {{ $port.nodePort }}
+    nodePort: {{ $port.NodePort }}
     {{ end }}
   selector:
     app: {{ $config.labels.app }}


### PR DESCRIPTION
Quando é consolidado os manifestos é alterado alguns parâmetros do arquivo values.yaml onde o nodePort assume NodePort 

Se observar no exemplo fornecido na documentação, poderá ver que o serviço giropops-senhas-app não está com o valor 32500 contido no values.yaml
```bash
NAME                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/giropops-senhas   3/3     3            3           69s
deployment.apps/redis             1/1     1            1           69s

NAME                                   READY   STATUS    RESTARTS   AGE
pod/giropops-senhas-8598bc5699-68sn6   1/1     Running   0          69s
pod/giropops-senhas-8598bc5699-wgnxj   1/1     Running   0          69s
pod/giropops-senhas-8598bc5699-xqssx   1/1     Running   0          69s
pod/redis-69c5869684-62d2h             1/1     Running   0          69s

NAME                              TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
service/giropops-senhas-app       NodePort    10.96.119.23   <none>        5000:**30032**/TCP   69s
service/giropops-senhas-metrics   ClusterIP   10.96.110.83   <none>        8088/TCP         69s
service/kubernetes                ClusterIP   10.96.0.1      <none>        443/TCP          3d22h
service/redis-service             ClusterIP   10.96.77.187   <none>        6379/TCP         69s
```