### PR TITLE
Ajuste de identação no arquivo values.yaml relacionado ao databases

### DIFF
--- a/pt/day-16/README.md
+++ b/pt/day-16/README.md
@@ -1218,9 +1218,9 @@ A configuração no `values.yaml`:
 databases:
   giropops-senhas:
     type: "MySQL"
-      host: "mysql.svc.cluster.local"
-      port: 3306
-      name: "MyDB"
+    host: "mysql.svc.cluster.local"
+    port: 3306
+    name: "MyDB"
 ```
 
 Com isso, já podemos criar um ConfigMap que inclui essa configuração como uma string YAML:

--- a/pt/day-16/README.md
+++ b/pt/day-16/README.md
@@ -1084,7 +1084,7 @@ spec:
     protocol: TCP
     name: {{ $port.name }}
     {{ if eq $port.serviceType "NodePort" }}
-    nodePort: {{ $port.nodePort }}
+    nodePort: {{ $port.NodePort }}
     {{ end }}
   selector:
     app: {{ $config.labels.app }}


### PR DESCRIPTION
Da forma atual, o helm da erro para instalar a aplicação. 

```bash
databases:
  giropops-senhas:
    type: "MySQL"
      host: "mysql.svc.cluster.local"
      port: 3306
      name: "MyDB"
```
No caso acredito que host, port, name devam estar na mesma identação. Desta forma é possível instalar a aplicação. 
Ou então remover o "MySQL" de type.