### PR TITLE
ajususte do filtro para listagem de pods

### DIFF
--- a/pt/day-3/README.md
+++ b/pt/day-3/README.md
@@ -204,7 +204,7 @@ nginx-deployment-78cd4b8fd-r4zk8   1/1     Running   0          5s
 Para verificar os Pods que o Deployment está gerenciando nós precisamos executar o seguinte comando:
 
 ```bash
-kubectl get pods -l app=nginx
+kubectl get pods -l app=nginx-deployment
 ```
 
 O resultado será o seguinte:


### PR DESCRIPTION
no tuturial apresenta  o filtro como

``` bash
 kubectl get pods -l app=nginx
 ```
 mas entendo que deveria ser:
 
 ```bash
  kubectl get pods -l app=nginx-deployment
```